### PR TITLE
Added keyring auth example

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,3 +23,4 @@ sphinx-autobuild==0.6.0
 sphinx-rtd-theme==0.2.4
 tornado==4.5.1
 watchdog==0.8.3
+keyring==15.1.0

--- a/keyring_tests.py
+++ b/keyring_tests.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from nineapi.client import Client, APIException
+import os
+import sys
+import keyring
+
+#While using the program the follwing command should be run only once,the system will store the creds.
+keyring.set_password('9gag',username,password)
+
+class APITest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.username = username
+        self.password = keyring.get_password('9gag',username)
+
+    def test_log_in_good(self):
+        response = self.client.log_in(self.username, self.password)
+        self.assertEqual(response, True)
+
+    def test_log_in_bad(self):
+        self.assertRaises(APIException, lambda: self.client.log_in(self.username, self.password + 'wrong'))
+
+    def test_get_posts(self):
+        self.test_log_in_good()
+        posts = self.client.get_posts()
+        self.assertEqual(len(posts), 10)
+
+#Delete keyring since it is for test only
+keyring.delete_password('9gag',username)

--- a/keyring_tests.py
+++ b/keyring_tests.py
@@ -5,6 +5,8 @@ import sys
 import keyring
 
 #While using the program the follwing command should be run only once,the system will store the creds.
+username=""
+password="" #This should be removed after setting the password
 keyring.set_password('9gag',username,password)
 
 class APITest(TestCase):


### PR DESCRIPTION
[Keyring](https://pypi.org/project/keyring/) is the recommended use for storing password.
Python provides nice bindings for keyrings implemented on various systems.

The following command should be run only once,the system will do the rest:
`keyring.set_password('9gag','username',password)`

The password can be accessed using `keyring.get_password('9gag','username')`

I updated the requirements.txt to include keyring module and added keyring_tests.py as an example.